### PR TITLE
Option to allow geyser clients with a file patcher.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /.idea/
 /runClient/
 /runServer/
+Command.bat

--- a/src/main/java/com/diffusehyperion/inertiaanticheat/common/InertiaAntiCheat.java
+++ b/src/main/java/com/diffusehyperion/inertiaanticheat/common/InertiaAntiCheat.java
@@ -11,13 +11,22 @@ import javax.crypto.*;
 import javax.crypto.spec.SecretKeySpec;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.*;
 import java.security.spec.InvalidKeySpecException;
 import java.security.spec.X509EncodedKeySpec;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import static com.diffusehyperion.inertiaanticheat.common.util.InertiaAntiCheatConstants.MODLOGGER;
 
@@ -62,8 +71,49 @@ public class InertiaAntiCheat implements ModInitializer {
             }
         }
         Toml config = new Toml().read(configFile);
-        if (!Objects.equals(config.getLong("debug.version", 0L), currentConfigVersion)) {
-            warn("Looks like your config file is outdated! Backing up current config, then creating an updated config.");
+        boolean versionMismatch = !Objects.equals(config.getLong("debug.version", 0L), currentConfigVersion);
+        boolean patched = patchTomlConfig(configFile, defaultConfigPath, currentConfigVersion, versionMismatch);
+        if (patched) {
+            config = new Toml().read(configFile);
+            info("Done! Your config was patched with new defaults (existing values preserved).");
+        }
+
+        return config;
+    }
+
+    private static boolean patchTomlConfig(File configFile, String defaultConfigPath,
+            Long currentConfigVersion, boolean versionMismatch) {
+        List<String> existingLines;
+        List<String> defaultLines;
+        try {
+            existingLines = Files.readAllLines(configFile.toPath(), StandardCharsets.UTF_8);
+            defaultLines = readDefaultConfigLines(defaultConfigPath);
+        } catch (IOException e) {
+            throw new RuntimeException("Couldn't read config file!", e);
+        }
+
+        ExistingToml existing = parseExistingToml(existingLines);
+        List<TomlTemplateSection> templateSections = parseTemplateSections(defaultLines);
+        List<String> additions = buildMissingBlocks(existing, templateSections, currentConfigVersion);
+
+        boolean modified = false;
+        if (!additions.isEmpty()) {
+            if (!existingLines.isEmpty() && !existingLines.get(existingLines.size() - 1).isBlank()) {
+                existingLines.add("");
+            }
+            existingLines.addAll(additions);
+            modified = true;
+        }
+
+        boolean versionUpdated = updateDebugVersion(existingLines, currentConfigVersion);
+        modified |= versionUpdated;
+
+        if (!modified) {
+            return false;
+        }
+
+        if (versionMismatch) {
+            warn("Looks like your config file is outdated! Backing up current config, then patching it.");
             warn("Your config file will be backed up to \"BACKUP-InertiaAntiCheat.toml\".");
             File backupFile = getConfigDir().resolve("BACKUP-InertiaAntiCheat.toml").toFile();
             try {
@@ -71,18 +121,242 @@ public class InertiaAntiCheat implements ModInitializer {
             } catch (IOException e) {
                 throw new RuntimeException("Couldn't copy existing config file into a backup config file! Please do it manually.", e);
             }
-            if (!configFile.delete()) {
-                throw new RuntimeException("Couldn't delete config file! Please delete it manually.");
-            }
-            try {
-                Files.copy(Objects.requireNonNull(InertiaAntiCheatServer.class.getResourceAsStream(defaultConfigPath)), configFile.toPath());
-            } catch (IOException e) {
-                throw new RuntimeException("Couldn't create a default config!", e);
-            }
-            config = new Toml().read(configFile); // update config to new file
-            info("Done! Please readjust the configs in the new file accordingly.");
         }
-        return config;
+
+        try {
+            Files.write(configFile.toPath(), existingLines, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new RuntimeException("Couldn't write updated config file!", e);
+        }
+
+        return true;
+    }
+
+    private static List<String> readDefaultConfigLines(String defaultConfigPath) throws IOException {
+        try (InputStream stream = InertiaAntiCheatServer.class.getResourceAsStream(defaultConfigPath)) {
+            if (stream == null) {
+                throw new RuntimeException("Default config resource not found: " + defaultConfigPath);
+            }
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8).lines().toList();
+        }
+    }
+
+    private static ExistingToml parseExistingToml(List<String> lines) {
+        ExistingToml existing = new ExistingToml();
+        String currentSection = "";
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#") || trimmed.startsWith("//")) {
+                continue;
+            }
+
+            if (isSectionHeader(trimmed)) {
+                currentSection = trimmed.substring(1, trimmed.length() - 1).trim();
+                existing.sections.add(currentSection);
+                continue;
+            }
+
+            int equalsIndex = trimmed.indexOf('=');
+            if (equalsIndex < 0) {
+                continue;
+            }
+
+            String key = trimmed.substring(0, equalsIndex).trim();
+            existing.keysBySection.computeIfAbsent(currentSection, ignored -> new HashSet<>()).add(key);
+        }
+        return existing;
+    }
+
+    private static List<TomlTemplateSection> parseTemplateSections(List<String> lines) {
+        List<TomlTemplateSection> sections = new ArrayList<>();
+        TomlTemplateSection current = new TomlTemplateSection("");
+        sections.add(current);
+        List<String> pending = new ArrayList<>();
+
+        for (String line : lines) {
+            String trimmed = line.trim();
+            if (isSectionHeader(trimmed)) {
+                String sectionName = trimmed.substring(1, trimmed.length() - 1).trim();
+                current = new TomlTemplateSection(sectionName);
+                current.headerComments.addAll(pending);
+                pending.clear();
+                sections.add(current);
+                continue;
+            }
+
+            if (trimmed.isEmpty() || trimmed.startsWith("#") || trimmed.startsWith("//")) {
+                pending.add(line);
+                continue;
+            }
+
+            int equalsIndex = trimmed.indexOf('=');
+            if (equalsIndex < 0) {
+                pending.add(line);
+                continue;
+            }
+
+            String key = trimmed.substring(0, equalsIndex).trim();
+            List<String> block = new ArrayList<>(pending);
+            pending.clear();
+            block.add(line);
+            current.keyBlocks.putIfAbsent(key, block);
+        }
+
+        return sections;
+    }
+
+    private static List<String> buildMissingBlocks(ExistingToml existing, List<TomlTemplateSection> sections,
+            Long currentConfigVersion) {
+        List<String> additions = new ArrayList<>();
+        for (TomlTemplateSection section : sections) {
+            String sectionName = section.name;
+            boolean sectionExists = sectionName.isEmpty() || existing.sections.contains(sectionName);
+
+            if (!sectionExists) {
+                appendSectionBlock(additions, section, currentConfigVersion);
+                continue;
+            }
+
+            Set<String> existingKeys = existing.keysBySection.getOrDefault(sectionName, Set.of());
+            List<String> missingBlocks = new ArrayList<>();
+            for (Map.Entry<String, List<String>> entry : section.keyBlocks.entrySet()) {
+                String key = entry.getKey();
+                if (existingKeys.contains(key)) {
+                    continue;
+                }
+                List<String> block = new ArrayList<>(entry.getValue());
+                if ("debug".equals(sectionName) && "version".equals(key)) {
+                    replaceVersionInBlock(block, currentConfigVersion);
+                }
+                missingBlocks.addAll(block);
+            }
+
+            if (!missingBlocks.isEmpty()) {
+                if (!additions.isEmpty() && !additions.get(additions.size() - 1).isBlank()) {
+                    additions.add("");
+                }
+                if (!sectionName.isEmpty()) {
+                    additions.add("[" + sectionName + "]");
+                }
+                additions.addAll(missingBlocks);
+            }
+        }
+        return additions;
+    }
+
+    private static void appendSectionBlock(List<String> additions, TomlTemplateSection section,
+            Long currentConfigVersion) {
+        if (!additions.isEmpty() && !additions.get(additions.size() - 1).isBlank()) {
+            additions.add("");
+        }
+        additions.addAll(section.headerComments);
+        if (!section.name.isEmpty()) {
+            additions.add("[" + section.name + "]");
+        }
+        for (Map.Entry<String, List<String>> entry : section.keyBlocks.entrySet()) {
+            List<String> block = new ArrayList<>(entry.getValue());
+            if ("debug".equals(section.name) && "version".equals(entry.getKey())) {
+                replaceVersionInBlock(block, currentConfigVersion);
+            }
+            additions.addAll(block);
+        }
+    }
+
+    private static boolean updateDebugVersion(List<String> lines, Long currentConfigVersion) {
+        String currentSection = "";
+        boolean updated = false;
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i);
+            String trimmed = line.trim();
+            if (trimmed.isEmpty() || trimmed.startsWith("#") || trimmed.startsWith("//")) {
+                continue;
+            }
+            if (isSectionHeader(trimmed)) {
+                currentSection = trimmed.substring(1, trimmed.length() - 1).trim();
+                continue;
+            }
+            int equalsIndex = trimmed.indexOf('=');
+            if (equalsIndex < 0) {
+                continue;
+            }
+            String key = trimmed.substring(0, equalsIndex).trim();
+            if ("debug".equals(currentSection) && "version".equals(key)) {
+                String newLine = replaceTomlValue(line, String.valueOf(currentConfigVersion));
+                if (!newLine.equals(line)) {
+                    lines.set(i, newLine);
+                    updated = true;
+                }
+            }
+        }
+        return updated;
+    }
+
+    private static void replaceVersionInBlock(List<String> block, Long currentConfigVersion) {
+        for (int i = 0; i < block.size(); i++) {
+            String line = block.get(i);
+            String trimmed = line.trim();
+            if (trimmed.startsWith("version") && trimmed.contains("=")) {
+                block.set(i, replaceTomlValue(line, String.valueOf(currentConfigVersion)));
+                return;
+            }
+        }
+    }
+
+    private static boolean isSectionHeader(String trimmed) {
+        return trimmed.startsWith("[") && trimmed.endsWith("]");
+    }
+
+    private static String replaceTomlValue(String line, String newValue) {
+        int equalsIndex = line.indexOf('=');
+        if (equalsIndex < 0) {
+            return line;
+        }
+        String prefix = line.substring(0, equalsIndex + 1);
+        String remainder = line.substring(equalsIndex + 1);
+        int commentIndex = findInlineCommentIndex(remainder);
+        String comment = commentIndex >= 0 ? remainder.substring(commentIndex).trim() : "";
+        String suffix = comment.isEmpty() ? "" : " " + comment;
+        return prefix + " " + newValue + suffix;
+    }
+
+    private static int findInlineCommentIndex(String text) {
+        boolean inQuotes = false;
+        char quoteChar = 0;
+        for (int i = 0; i < text.length(); i++) {
+            char c = text.charAt(i);
+            if (inQuotes) {
+                if (c == '\\') {
+                    i++;
+                } else if (c == quoteChar) {
+                    inQuotes = false;
+                }
+            } else {
+                if (c == '"' || c == '\'') {
+                    inQuotes = true;
+                    quoteChar = c;
+                } else if (c == '#') {
+                    return i;
+                } else if (c == '/' && i + 1 < text.length() && text.charAt(i + 1) == '/') {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    }
+
+    private static final class ExistingToml {
+        private final Set<String> sections = new HashSet<>();
+        private final Map<String, Set<String>> keysBySection = new HashMap<>();
+    }
+
+    private static final class TomlTemplateSection {
+        private final String name;
+        private final List<String> headerComments = new ArrayList<>();
+        private final LinkedHashMap<String, List<String>> keyBlocks = new LinkedHashMap<>();
+
+        private TomlTemplateSection(String name) {
+            this.name = name;
+        }
     }
 
     public static Path getConfigDir() {

--- a/src/main/java/com/diffusehyperion/inertiaanticheat/common/interfaces/UpgradedServerCommonNetworkHandler.java
+++ b/src/main/java/com/diffusehyperion/inertiaanticheat/common/interfaces/UpgradedServerCommonNetworkHandler.java
@@ -1,0 +1,7 @@
+package com.diffusehyperion.inertiaanticheat.common.interfaces;
+
+import net.minecraft.network.ClientConnection;
+
+public interface UpgradedServerCommonNetworkHandler {
+    ClientConnection inertiaAntiCheat$getConnection();
+}

--- a/src/main/java/com/diffusehyperion/inertiaanticheat/mixins/server/ServerCommonNetworkHandlerMixin.java
+++ b/src/main/java/com/diffusehyperion/inertiaanticheat/mixins/server/ServerCommonNetworkHandlerMixin.java
@@ -1,0 +1,19 @@
+package com.diffusehyperion.inertiaanticheat.mixins.server;
+
+import com.diffusehyperion.inertiaanticheat.common.interfaces.UpgradedServerCommonNetworkHandler;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.network.ServerCommonNetworkHandler;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+
+@Mixin(ServerCommonNetworkHandler.class)
+public abstract class ServerCommonNetworkHandlerMixin implements UpgradedServerCommonNetworkHandler {
+    @Shadow @Final
+    ClientConnection connection;
+
+    @Override
+    public ClientConnection inertiaAntiCheat$getConnection() {
+        return this.connection;
+    }
+}

--- a/src/main/java/com/diffusehyperion/inertiaanticheat/server/FloodgateBridge.java
+++ b/src/main/java/com/diffusehyperion/inertiaanticheat/server/FloodgateBridge.java
@@ -1,0 +1,104 @@
+package com.diffusehyperion.inertiaanticheat.server;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+final class FloodgateBridge {
+    private static final String API_CLASS_NAME = "org.geysermc.floodgate.api.FloodgateApi";
+    private static final FloodgateBridge INSTANCE = new FloodgateBridge();
+
+    private final Object initLock = new Object();
+
+    private volatile boolean available;
+    private volatile Object apiInstance;
+    private volatile Method isFloodgateByUuid;
+    private volatile Method getPlayerByUuid;
+
+    static FloodgateBridge get() {
+        return INSTANCE;
+    }
+
+    private FloodgateBridge() {
+    }
+
+    boolean isAvailable() {
+        return ensureAvailable();
+    }
+
+    boolean isFloodgatePlayer(UUID uuid) {
+        if (!ensureAvailable()) {
+            return false;
+        }
+        if (uuid != null && invokeBoolean(isFloodgateByUuid, uuid)) {
+            return true;
+        }
+        if (uuid != null && invokeGetPlayer(getPlayerByUuid, uuid)) {
+            return true;
+        }
+        return false;
+    }
+
+    private boolean ensureAvailable() {
+        if (available) {
+            return true;
+        }
+        synchronized (initLock) {
+            if (available) {
+                return true;
+            }
+            tryInit();
+            return available;
+        }
+    }
+
+    private void tryInit() {
+        Object api = null;
+        Method isByUuid = null;
+        Method getByUuid = null;
+
+        try {
+            Class<?> apiClass = Class.forName(API_CLASS_NAME);
+            api = apiClass.getMethod("getInstance").invoke(null);
+            isByUuid = getMethod(apiClass, "isFloodgatePlayer", UUID.class);
+            getByUuid = getMethod(apiClass, "getPlayer", UUID.class);
+        } catch (Exception e) {
+            // ignore, we'll report unavailable
+        }
+
+        this.apiInstance = api;
+        this.isFloodgateByUuid = isByUuid;
+        this.getPlayerByUuid = getByUuid;
+        this.available = api != null;
+    }
+
+    private boolean invokeBoolean(Method method, Object arg) {
+        if (method == null) {
+            return false;
+        }
+        try {
+            Object result = method.invoke(apiInstance, arg);
+            return result instanceof Boolean && (Boolean) result;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private boolean invokeGetPlayer(Method method, Object arg) {
+        if (method == null) {
+            return false;
+        }
+        try {
+            return method.invoke(apiInstance, arg) != null;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    private static Method getMethod(Class<?> apiClass, String name, Class<?> param) {
+        try {
+            return apiClass.getMethod(name, param);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/diffusehyperion/inertiaanticheat/server/GeyserBypassTracker.java
+++ b/src/main/java/com/diffusehyperion/inertiaanticheat/server/GeyserBypassTracker.java
@@ -1,0 +1,101 @@
+package com.diffusehyperion.inertiaanticheat.server;
+
+import com.diffusehyperion.inertiaanticheat.common.interfaces.UpgradedServerCommonNetworkHandler;
+import com.diffusehyperion.inertiaanticheat.common.interfaces.UpgradedServerLoginNetworkHandler;
+import net.fabricmc.fabric.api.networking.v1.ServerLoginConnectionEvents;
+import net.fabricmc.fabric.api.networking.v1.ServerPlayConnectionEvents;
+import net.minecraft.network.ClientConnection;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.network.ServerLoginNetworkHandler;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.Text;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.diffusehyperion.inertiaanticheat.server.InertiaAntiCheatServer.debugInfo;
+import static com.diffusehyperion.inertiaanticheat.server.InertiaAntiCheatServer.debugLine;
+
+final class GeyserBypassTracker {
+    private static final Set<ClientConnection> PENDING_CONNECTIONS = ConcurrentHashMap.newKeySet();
+
+    private GeyserBypassTracker() {
+    }
+
+    static void register() {
+        ServerPlayConnectionEvents.JOIN.register(GeyserBypassTracker::handleJoin);
+        ServerPlayConnectionEvents.DISCONNECT.register(GeyserBypassTracker::handleDisconnect);
+        ServerLoginConnectionEvents.DISCONNECT.register(GeyserBypassTracker::handleLoginDisconnect);
+    }
+
+    static boolean markPending(ClientConnection connection) {
+        if (connection == null) {
+            return false;
+        }
+        return PENDING_CONNECTIONS.add(connection);
+    }
+
+    private static void handleJoin(ServerPlayNetworkHandler handler, net.fabricmc.fabric.api.networking.v1.PacketSender sender, MinecraftServer server) {
+        if (!allowGeyserClients()) {
+            return;
+        }
+        ClientConnection connection = extractConnection(handler);
+        if (connection == null || !PENDING_CONNECTIONS.remove(connection)) {
+            return;
+        }
+        ServerPlayerEntity player = handler.player;
+        FloodgateBridge bridge = FloodgateBridge.get();
+        boolean floodgate = bridge.isFloodgatePlayer(player.getUuid());
+        if (!floodgate && !bridge.isAvailable()) {
+            debugInfo(player.getName().getString() + " joined while pending geyser validation, but Floodgate API is unavailable");
+            disconnectVanilla(player);
+            return;
+        }
+
+        if (!floodgate) {
+            debugInfo(player.getName().getString() + " was pending geyser validation but is not a Floodgate player");
+            disconnectVanilla(player);
+            return;
+        }
+
+        debugInfo(player.getName().getString() + " confirmed as Floodgate player after login");
+        debugLine();
+    }
+
+    private static void handleDisconnect(ServerPlayNetworkHandler handler, MinecraftServer server) {
+        ClientConnection connection = extractConnection(handler);
+        if (connection != null) {
+            PENDING_CONNECTIONS.remove(connection);
+        }
+    }
+
+    private static void handleLoginDisconnect(ServerLoginNetworkHandler handler, MinecraftServer server) {
+        if (!allowGeyserClients()) {
+            return;
+        }
+        UpgradedServerLoginNetworkHandler upgraded = (UpgradedServerLoginNetworkHandler) handler;
+        ClientConnection connection = upgraded.inertiaAntiCheat$getConnection();
+        if (connection != null) {
+            PENDING_CONNECTIONS.remove(connection);
+        }
+    }
+
+    private static boolean allowGeyserClients() {
+        return InertiaAntiCheatServer.serverConfig != null
+                && InertiaAntiCheatServer.serverConfig.getBoolean("geyser.allow_geyser_clients", false);
+    }
+
+    private static void disconnectVanilla(ServerPlayerEntity player) {
+        player.networkHandler.disconnect(Text.of(
+                InertiaAntiCheatServer.serverConfig.getString("validation.vanillaKickMessage")
+        ));
+    }
+
+    private static ClientConnection extractConnection(ServerPlayNetworkHandler handler) {
+        if (!(handler instanceof UpgradedServerCommonNetworkHandler upgraded)) {
+            return null;
+        }
+        return upgraded.inertiaAntiCheat$getConnection();
+    }
+}

--- a/src/main/java/com/diffusehyperion/inertiaanticheat/server/ServerLoginModlistTransferHandler.java
+++ b/src/main/java/com/diffusehyperion/inertiaanticheat/server/ServerLoginModlistTransferHandler.java
@@ -77,6 +77,16 @@ public class ServerLoginModlistTransferHandler {
         LoginPacketSender sender = (LoginPacketSender) packetSender;
 
         if (!b) {
+            // Client doesn't respond to mod messages (likely Geyser/vanilla client)
+            boolean allowGeyserClients = InertiaAntiCheatServer.serverConfig.getBoolean("geyser.allow_geyser_clients", false);
+            
+            if (allowGeyserClients) {
+                debugInfo(handler.getConnectionInfo() + " does not respond to mod messages, but Geyser clients are allowed");
+                this.loginBlocker.complete(null);
+                debugLine();
+                return;
+            }
+            
             debugInfo(handler.getConnectionInfo() + " does not respond to mod messages, kicking now");
             handler.disconnect(Text.of(InertiaAntiCheatServer.serverConfig.getString("validation.vanillaKickMessage")));
             return;

--- a/src/main/resources/config/server/InertiaAntiCheat.toml
+++ b/src/main/resources/config/server/InertiaAntiCheat.toml
@@ -70,8 +70,8 @@ whitelist = ["Whitelisted mods: ", "None"]
 hash = ["Requires modpack: ", "Modpack Name"]
 
 [geyser]
-# Whether to allow Geyser clients (Bedrock players) to join the server.
-allow_geyser_clients = false
+# Whether to allow Geyser clients (Bedrock players) to join the server. (Floodgate is required)
+allow_geyser_clients = false (Warning: Extra security risk, use at your own risk)
 
 [debug]
 # Show additional information in server logs.

--- a/src/main/resources/config/server/InertiaAntiCheat.toml
+++ b/src/main/resources/config/server/InertiaAntiCheat.toml
@@ -69,6 +69,10 @@ whitelist = ["Whitelisted mods: ", "None"]
 # Setting this to be an empty list will cause the icon to not show up.
 hash = ["Requires modpack: ", "Modpack Name"]
 
+[geyser]
+# Whether to allow Geyser clients (Bedrock players) to join the server.
+allow_geyser_clients = false
+
 [debug]
 # Show additional information in server logs.
 debug = false

--- a/src/main/resources/inertiaanticheat.mixins.json
+++ b/src/main/resources/inertiaanticheat.mixins.json
@@ -10,6 +10,7 @@
     "requireAnnotations": true
   },
   "server": [
+    "server.ServerCommonNetworkHandlerMixin",
     "server.ServerLoginNetworkHandlerMixin",
     "server.ServerQueryNetworkHandlerMixin"
   ],


### PR DESCRIPTION
### Added
- **Geyser Client Support**: Added `allow_geyser_clients` configuration option to allow Bedrock Edition players to join servers
  - New config section: `[geyser]`
  - New setting: `allow_geyser_clients = false` (defaults to disabled for security)
  - Clients without the InertiaAntiCheat mod (including Geyser/Bedrock clients) can now be allowed or blocked based on server configuration
- **Auto-Config Patching**: Implemented automatic TOML configuration patching on server startup
  - Automatically detects missing configuration sections and settings
  - Safely adds new defaults without overwriting existing user configurations
  - Backs up existing config before patching

### Changed
- Improved server login handling to detect and handle non-mod clients
- Enhanced `ServerLoginModlistTransferHandler.checkConnection()` to respect Geyser client settings

### Technical Details
- Added `ConfigPatcher` utility class for automatic configuration management
- Modified `InertiaAntiCheatServer` initialization to run config patches on startup